### PR TITLE
Fixed color creation when using CSS with 3 or 4 characters

### DIFF
--- a/NSColor/NSColor+Hex.m
+++ b/NSColor/NSColor+Hex.m
@@ -49,21 +49,21 @@
 	three:
 		a = @"FF";
 		r = [css substringWithRange:NSMakeRange(0, 1)];
-		r = [r stringByAppendingString:a];
+		r = [r stringByAppendingString:r];
 		g = [css substringWithRange:NSMakeRange(1, 1)];
-		g = [g stringByAppendingString:a];
+		g = [g stringByAppendingString:g];
 		b = [css substringWithRange:NSMakeRange(2, 1)];
-		b = [b stringByAppendingString:a];
+		b = [b stringByAppendingString:b];
 	}
 	else if (len == 4) {
 		a = [css substringWithRange:NSMakeRange(0, 1)];
 		a = [a stringByAppendingString:a];
 		r = [css substringWithRange:NSMakeRange(1, 1)];
-		r = [r stringByAppendingString:a];
+		r = [r stringByAppendingString:r];
 		g = [css substringWithRange:NSMakeRange(2, 1)];
-		g = [g stringByAppendingString:a];
+		g = [g stringByAppendingString:g];
 		b = [css substringWithRange:NSMakeRange(3, 1)];
-		b = [b stringByAppendingString:a];
+		b = [b stringByAppendingString:b];
 	}
 	else if (len == 5 || len == 7) {
 		css = [@"0" stringByAppendingString:css];

--- a/UIColor/UIColor+Hex.m
+++ b/UIColor/UIColor+Hex.m
@@ -49,21 +49,21 @@
 	three:
 		a = @"FF";
 		r = [css substringWithRange:NSMakeRange(0, 1)];
-		r = [r stringByAppendingString:a];
+		r = [r stringByAppendingString:r];
 		g = [css substringWithRange:NSMakeRange(1, 1)];
-		g = [g stringByAppendingString:a];
+		g = [g stringByAppendingString:g];
 		b = [css substringWithRange:NSMakeRange(2, 1)];
-		b = [b stringByAppendingString:a];
+		b = [b stringByAppendingString:b];
 	}
 	else if (len == 4) {
 		a = [css substringWithRange:NSMakeRange(0, 1)];
 		a = [a stringByAppendingString:a];
 		r = [css substringWithRange:NSMakeRange(1, 1)];
-		r = [r stringByAppendingString:a];
+		r = [r stringByAppendingString:r];
 		g = [css substringWithRange:NSMakeRange(2, 1)];
-		g = [g stringByAppendingString:a];
+		g = [g stringByAppendingString:g];
 		b = [css substringWithRange:NSMakeRange(3, 1)];
-		b = [b stringByAppendingString:a];
+		b = [b stringByAppendingString:b];
 	}
 	else if (len == 5 || len == 7) {
 		css = [@"0" stringByAppendingString:css];


### PR DESCRIPTION
When the CSS string uses a single character for the individual R, G, & B values, the single value is appended for each R, G, & B value instead of the alpha value getting appended.  For example, "#ABC" will become "#AABBCC".